### PR TITLE
Magestore_onestep run original function when not Afterpay

### DIFF
--- a/src/js/Afterpay/checkout/magestore_onestep.js
+++ b/src/js/Afterpay/checkout/magestore_onestep.js
@@ -121,6 +121,12 @@
                         }
                     }
                 );
+            } else {
+                /**
+                 * Call original function
+                 */
+                original.apply(this, arguments);
+            }
             }
         };
     }


### PR DESCRIPTION
This is needed for other payment methods like Paypal. Without it, Paypal doesn't redirect at all